### PR TITLE
Avoid build breaking error in Jazzy.

### DIFF
--- a/include/kinematics_interface_pinocchio/kinematics_interface_pinocchio.hpp
+++ b/include/kinematics_interface_pinocchio/kinematics_interface_pinocchio.hpp
@@ -64,6 +64,11 @@ public:
         Eigen::Matrix<double, 6, Eigen::Dynamic>& jacobian
     ) override;
 
+    bool calculate_jacobian_inverse(
+        const Eigen::VectorXd & joint_pos, const std::string & link_name,
+        Eigen::Matrix<double, Eigen::Dynamic, 6> & jacobian_inverse
+    ) override;
+
 private:
     // verification methods
     bool verify_initialized();


### PR DESCRIPTION
The current released version of this package in `jazzy` is broken due to upstream changes in `kinematics_interface`. This means the package will be wiped out from the `jazzy` repos in the upcoming sync at the end of this week (https://repo.ros2.org/status_page/ros_jazzy_default.html?q=REGRESSION).

To avoid that we can add the function and release the package to `jazzy` so at least compiles as is. Of course the best would be to actually add the implementation of it.

## Summary by Sourcery

Add a placeholder implementation of calculate_jacobian_inverse to prevent package build failure in ROS 2 Jazzy

Bug Fixes:
- Prevent package from being removed from Jazzy repositories by adding a stub implementation of calculate_jacobian_inverse method

Enhancements:
- Declare calculate_jacobian_inverse method in the KinematicsInterfacePinocchio class to meet interface requirements