### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,7 @@ target_include_directories(kinematics_interface_pinocchio PUBLIC
 )
 target_compile_features(kinematics_interface_pinocchio PUBLIC cxx_std_17)
 target_link_libraries(kinematics_interface_pinocchio PUBLIC
-  ${THIS_PACKAGE_INCLUDE_DEPENDS}
-)
-target_link_libraries(kinematics_interface_pinocchio PUBLIC
-  Eigen3::Eigen pinocchio::pinocchio
+  Eigen3::Eigen kinematics_interface::kinematics_interface pinocchio::pinocchio pluginlib::pluginlib
 )
 
 pluginlib_export_plugin_description_file(kinematics_interface kinematics_interface_pinocchio.xml)
@@ -46,11 +43,10 @@ if(BUILD_TESTING)
     test_kinematics_interface_pinocchio
     test/test_kinematics_interface_pinocchio.cpp
   )
-  target_link_libraries(test_kinematics_interface_pinocchio kinematics_interface_pinocchio)
+  target_link_libraries(test_kinematics_interface_pinocchio kinematics_interface_pinocchio ros2_control_test_assets::ros2_control_test_assets)
 
   # TODO: Use target_link_libraries once ros2_control_test_assets'
   #       CMake include export is fixed
-  ament_target_dependencies(test_kinematics_interface_pinocchio ros2_control_test_assets)
 endif()
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(kinematics_interface_pinocchio PUBLIC
   $<INSTALL_INTERFACE:include/kinematics_interface_pinocchio>
 )
 target_compile_features(kinematics_interface_pinocchio PUBLIC cxx_std_17)
-ament_target_dependencies(kinematics_interface_pinocchio PUBLIC
+target_link_libraries(kinematics_interface_pinocchio PUBLIC
   ${THIS_PACKAGE_INCLUDE_DEPENDS}
 )
 target_link_libraries(kinematics_interface_pinocchio PUBLIC


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.

## Summary by Sourcery

Enhancements:
- Replace deprecated `ament_target_dependencies` with `target_link_libraries` to align with ROS 2 Kilted release recommendations