### PR TITLE
implement calculate inverse jacobian

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![ROS Rolling](https://img.shields.io/badge/ROS-Rolling-brightgreen.svg?logo=ros)](https://docs.ros.org/en/rolling/index.html)
 
 A [Pinocchio](https://github.com/stack-of-tasks/pinocchio)-based [ROS 2 Kinematics Interface](https://github.com/ros-controls/kinematics_interface) plugin. This can serve as a drop-in replacement for the default [KDL plugin](https://github.com/ros-controls/kinematics_interface/tree/master/kinematics_interface_kdl) in ROS 2, offering a different backend for forward and inverse kinematics.
+Requires pinocchio to be installed: `apt install ros-rolling-pinocchio`.
 
 ---
 

--- a/include/kinematics_interface_pinocchio/kinematics_interface_pinocchio.hpp
+++ b/include/kinematics_interface_pinocchio/kinematics_interface_pinocchio.hpp
@@ -64,6 +64,11 @@ public:
         Eigen::Matrix<double, 6, Eigen::Dynamic>& jacobian
     ) override;
 
+    bool calculate_jacobian_inverse(
+        const Eigen::VectorXd & joint_pos, const std::string & link_name,
+        Eigen::Matrix<double, Eigen::Dynamic, 6> & jacobian_inverse
+    ) override;
+
 private:
     // verification methods
     bool verify_initialized();

--- a/include/kinematics_interface_pinocchio/kinematics_interface_pinocchio.hpp
+++ b/include/kinematics_interface_pinocchio/kinematics_interface_pinocchio.hpp
@@ -40,8 +40,9 @@ class KinematicsInterfacePinocchio : public kinematics_interface::KinematicsInte
 {
 public:
     bool initialize(
+        const std::string& robot_description,
         std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface,
-        const std::string& end_effector_name
+        const std::string& param_namespace
     ) override;
 
     bool convert_cartesian_deltas_to_joint_deltas(

--- a/include/kinematics_interface_pinocchio/kinematics_interface_pinocchio.hpp
+++ b/include/kinematics_interface_pinocchio/kinematics_interface_pinocchio.hpp
@@ -65,8 +65,8 @@ public:
     ) override;
 
     bool calculate_jacobian_inverse(
-        const Eigen::VectorXd & joint_pos, const std::string & link_name,
-        Eigen::Matrix<double, Eigen::Dynamic, 6> & jacobian_inverse
+        const Eigen::VectorXd& joint_pos, const std::string& link_name,
+        Eigen::Matrix<double, Eigen::Dynamic, 6>& jacobian_inverse
     ) override;
 
 private:
@@ -75,6 +75,7 @@ private:
     bool verify_link_name(const std::string& link_name);
     bool verify_joint_vector(const Eigen::VectorXd& joint_vector);
     bool verify_jacobian(const Eigen::Matrix<double, 6, Eigen::Dynamic>& jacobian);
+    bool verify_jacobian_inverse(const Eigen::Matrix<double, Eigen::Dynamic, 6>& jacobian_inverse);
 
     bool initialized = false;
     std::string root_name_;
@@ -84,6 +85,7 @@ private:
     std::shared_ptr<pinocchio::Data> data_;
     Eigen::VectorXd q_;
     Eigen::MatrixXd jacobian_;
+    Eigen::Matrix<double, Eigen::Dynamic, 6> jacobian_inverse_;
     Eigen::MatrixXd frame_tf_;
 
     std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface_;

--- a/test/test_kinematics_interface_pinocchio.cpp
+++ b/test/test_kinematics_interface_pinocchio.cpp
@@ -28,6 +28,8 @@ public:
     std::shared_ptr<kinematics_interface::KinematicsInterface> ik_;
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node_;
     std::string end_effector_ = "link2";
+    std::string urdf_ =
+        std::string(ros2_control_test_assets::urdf_head) + std::string(ros2_control_test_assets::urdf_tail);
 
     void SetUp()
     {
@@ -71,17 +73,17 @@ TEST_F(TestPinocchioPlugin, Pinocchio_plugin_function)
     loadAlphaParameter();
 
     // initialize the  plugin
-    ASSERT_TRUE(ik_->initialize(node_->get_node_parameters_interface(), end_effector_));
+    ASSERT_TRUE(ik_->initialize(urdf_, node_->get_node_parameters_interface(), ""));
 
     // calculate end effector transform
-    Eigen::Matrix<double, Eigen::Dynamic, 1> pos = Eigen::Matrix<double, 2, 1>::Zero();
+    Eigen::Matrix<double, Eigen::Dynamic, 1> pos = Eigen::Matrix<double, 3, 1>::Zero();
     Eigen::Isometry3d end_effector_transform;
     ASSERT_TRUE(ik_->calculate_link_transform(pos, end_effector_, end_effector_transform));
 
     // convert cartesian delta to joint delta
     Eigen::Matrix<double, 6, 1> delta_x = Eigen::Matrix<double, 6, 1>::Zero();
     delta_x[2] = 1;
-    Eigen::Matrix<double, Eigen::Dynamic, 1> delta_theta = Eigen::Matrix<double, 2, 1>::Zero();
+    Eigen::Matrix<double, Eigen::Dynamic, 1> delta_theta = Eigen::Matrix<double, 3, 1>::Zero();
     ASSERT_TRUE(ik_->convert_cartesian_deltas_to_joint_deltas(pos, delta_x, end_effector_, delta_theta));
 
     // convert joint delta to cartesian delta
@@ -102,17 +104,17 @@ TEST_F(TestPinocchioPlugin, Pinocchio_plugin_function_std_vector)
     loadAlphaParameter();
 
     // initialize the  plugin
-    ASSERT_TRUE(ik_->initialize(node_->get_node_parameters_interface(), end_effector_));
+    ASSERT_TRUE(ik_->initialize(urdf_, node_->get_node_parameters_interface(), ""));
 
     // calculate end effector transform
-    std::vector<double> pos = {0, 0};
+    std::vector<double> pos = {0, 0, 0};
     Eigen::Isometry3d end_effector_transform;
     ASSERT_TRUE(ik_->calculate_link_transform(pos, end_effector_, end_effector_transform));
 
     // convert cartesian delta to joint delta
     std::vector<double> delta_x = {0, 0, 0, 0, 0, 0};
     delta_x[2] = 1;
-    std::vector<double> delta_theta = {0, 0};
+    std::vector<double> delta_theta = {0, 0, 0};
     ASSERT_TRUE(ik_->convert_cartesian_deltas_to_joint_deltas(pos, delta_x, end_effector_, delta_theta));
 
     // convert joint delta to cartesian delta
@@ -133,7 +135,7 @@ TEST_F(TestPinocchioPlugin, incorrect_input_sizes)
     loadAlphaParameter();
 
     // initialize the  plugin
-    ASSERT_TRUE(ik_->initialize(node_->get_node_parameters_interface(), end_effector_));
+    ASSERT_TRUE(ik_->initialize(urdf_, node_->get_node_parameters_interface(), ""));
 
     // define correct values
     Eigen::Matrix<double, Eigen::Dynamic, 1> pos = Eigen::Matrix<double, 2, 1>::Zero();
@@ -165,5 +167,5 @@ TEST_F(TestPinocchioPlugin, Pinocchio_plugin_no_robot_description)
 {
     // load alpha to parameter server
     loadAlphaParameter();
-    ASSERT_FALSE(ik_->initialize(node_->get_node_parameters_interface(), end_effector_));
+    ASSERT_FALSE(ik_->initialize("", node_->get_node_parameters_interface(), ""));
 }

--- a/test/test_kinematics_interface_pinocchio.cpp
+++ b/test/test_kinematics_interface_pinocchio.cpp
@@ -95,6 +95,25 @@ TEST_F(TestPinocchioPlugin, Pinocchio_plugin_function)
     {
         ASSERT_NEAR(delta_x[i], delta_x_est[i], 0.02);
     }
+
+    // calculate jacobian
+    Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian = Eigen::Matrix<double, 6, 3>::Zero();
+    ASSERT_TRUE(ik_->calculate_jacobian(pos, end_effector_, jacobian));
+
+    // calculate jacobian inverse
+    Eigen::Matrix<double, Eigen::Dynamic, 6> jacobian_inverse =
+        jacobian.completeOrthogonalDecomposition().pseudoInverse();
+    Eigen::Matrix<double, Eigen::Dynamic, 6> jacobian_inverse_est = Eigen::Matrix<double, 3, 6>::Zero();
+    ASSERT_TRUE(ik_->calculate_jacobian_inverse(pos, end_effector_, jacobian_inverse_est));
+
+    // ensure jacobian inverse math is correct
+    for (Eigen::Index i = 0; i < jacobian_inverse.rows(); ++i)
+    {
+        for (Eigen::Index j = 0; j < jacobian_inverse.cols(); ++j)
+        {
+            ASSERT_NEAR(jacobian_inverse(i, j), jacobian_inverse_est(i, j), 0.02);
+        }
+    }
 }
 
 TEST_F(TestPinocchioPlugin, Pinocchio_plugin_function_std_vector)
@@ -126,6 +145,25 @@ TEST_F(TestPinocchioPlugin, Pinocchio_plugin_function_std_vector)
     {
         ASSERT_NEAR(delta_x[i], delta_x_est[i], 0.02);
     }
+
+    // calculate jacobian
+    Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian = Eigen::Matrix<double, 6, 3>::Zero();
+    ASSERT_TRUE(ik_->calculate_jacobian(pos, end_effector_, jacobian));
+
+    // calculate jacobian inverse
+    Eigen::Matrix<double, Eigen::Dynamic, 6> jacobian_inverse =
+        jacobian.completeOrthogonalDecomposition().pseudoInverse();
+    Eigen::Matrix<double, Eigen::Dynamic, 6> jacobian_inverse_est = Eigen::Matrix<double, 3, 6>::Zero();
+    ASSERT_TRUE(ik_->calculate_jacobian_inverse(pos, end_effector_, jacobian_inverse_est));
+
+    // ensure jacobian inverse math is correct
+    for (Eigen::Index i = 0; i < jacobian_inverse.rows(); ++i)
+    {
+        for (Eigen::Index j = 0; j < jacobian_inverse.cols(); ++j)
+        {
+            ASSERT_NEAR(jacobian_inverse(i, j), jacobian_inverse_est(i, j), 0.02);
+        }
+    }
 }
 
 TEST_F(TestPinocchioPlugin, incorrect_input_sizes)
@@ -144,9 +182,12 @@ TEST_F(TestPinocchioPlugin, incorrect_input_sizes)
     delta_x[2] = 1;
     Eigen::Matrix<double, Eigen::Dynamic, 1> delta_theta = Eigen::Matrix<double, 2, 1>::Zero();
     Eigen::Matrix<double, 6, 1> delta_x_est;
+    Eigen::Matrix<double, Eigen::Dynamic, 6> jacobian = Eigen::Matrix<double, 2, 6>::Zero();
 
     // wrong size input vector
     Eigen::Matrix<double, Eigen::Dynamic, 1> vec_5 = Eigen::Matrix<double, 5, 1>::Zero();
+    // wrong size input jacobian
+    Eigen::Matrix<double, Eigen::Dynamic, 6> mat_5_6 = Eigen::Matrix<double, 5, 6>::Zero();
 
     // calculate transform
     ASSERT_FALSE(ik_->calculate_link_transform(vec_5, end_effector_, end_effector_transform));
@@ -161,6 +202,11 @@ TEST_F(TestPinocchioPlugin, incorrect_input_sizes)
     ASSERT_FALSE(ik_->convert_joint_deltas_to_cartesian_deltas(vec_5, delta_theta, end_effector_, delta_x_est));
     ASSERT_FALSE(ik_->convert_joint_deltas_to_cartesian_deltas(pos, vec_5, end_effector_, delta_x_est));
     ASSERT_FALSE(ik_->convert_joint_deltas_to_cartesian_deltas(pos, delta_theta, "link_not_in_model", delta_x_est));
+
+    // calculate jacobian inverse
+    ASSERT_FALSE(ik_->calculate_jacobian_inverse(vec_5, end_effector_, jacobian));
+    ASSERT_FALSE(ik_->calculate_jacobian_inverse(pos, end_effector_, mat_5_6));
+    ASSERT_FALSE(ik_->calculate_jacobian_inverse(pos, "link_not_in_model", jacobian));
 }
 
 TEST_F(TestPinocchioPlugin, Pinocchio_plugin_no_robot_description)


### PR DESCRIPTION
## Summary by Sourcery

Implement a damped inverse Jacobian computation in the Pinocchio kinematics plugin, refactor initialization to accept a direct URDF string and parameter namespace, and extend unit tests to cover the new functionality and error cases.

New Features:
- Expose a calculate_jacobian_inverse method to compute the damped inverse Jacobian for arbitrary joints and links
- Modify convert_cartesian_deltas_to_joint_deltas to use the new inverse Jacobian routine

Enhancements:
- Refactor initialize to accept a robot_description argument with optional parameter namespace and fallback to node parameters
- Add size verification and detailed error logging for jacobian_inverse and other input validations

Tests:
- Add tests for calculate_jacobian and calculate_jacobian_inverse correctness and size-mismatch error handling
- Update existing plugin tests to use the new initialize signature and expanded vector dimensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for calculating the Jacobian inverse for specified joint positions and links.
  * Exposed new methods to compute and validate the Jacobian and its inverse.

* **Improvements**
  * Enhanced initialization flexibility by accepting a robot description and parameter namespace.
  * Improved error logging and input validation for kinematics calculations.

* **Tests**
  * Expanded test coverage to include Jacobian and Jacobian inverse calculations, as well as error handling for invalid inputs.

* **Documentation**
  * Updated README to specify the requirement and installation instructions for the Pinocchio library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->